### PR TITLE
Short version

### DIFF
--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -1,23 +1,5 @@
 # Test-negative design: short primer
 
-## Draft outline
-
-- What is VE
-  - Known biases with any VE estimator
-- What is a TND study
-- There are 16 kinds of people:
-  - Vaccinated vs. not
-  - Infected with the pathogen of interest vs. not
-  - Seek a test vs. not
-  - Test positive vs. not
-- TND has access only to people who seek a test
-- "Actual" VE is: [insert risk ratio math]
-- TND estimator of VE is: [insert odds ratio math]
-- Note that TND estimator is unbiased only when: [assumptions]
-- Bias of TND estimator scales this way with underlying parameters: [discuss]
-
-"HLS" refers to Halloran, Longini, and Struchiner _Design and Analysis of Vaccine Studies_.
-
 ## Vaccine efficacy
 
 VE is the fractional reduction in the probability of an adverse outcome due to vaccination. For purposes of a test-negative design (TND) study, we further define VE to be:
@@ -37,9 +19,9 @@ $$
 
 A test-negative design (TND) is a study design that can be used to estimate VE. In a TND:
 
-- The population of interest are those individuals who received a diagnostic test
-- The main covariate of interest is vaccination status
-- The outcome of interest is the test result (positive or negative)
+- The population of interest are those individuals who received a diagnostic test, usually becomes they develop some symptoms, seek a test, and qualify for that test.
+- The main covariate of interest is vaccination status.
+- The outcome of interest is the test result (positive or negative).
 
 The data available in a TND ultimately reduces to a 2x2 table of counts:
 
@@ -52,24 +34,27 @@ The data available in a TND ultimately reduces to a 2x2 table of counts:
 
 ### Single-exposure model
 
-- Individuals are vaccinated with probability $v$
+- Individuals are vaccinated $V$ with probability $v$, or unvaccinated $U$
   - Here we assume perfect reporting about vaccine status; i.e., there is no one who is actually vaccinated who appears in the "not vaccinated" arm, nor vice versa
-- Individuals are exposed with probability $\varepsilon_V$ or $\varepsilon_U$
+- Individuals are exposed with probability $P[E|V]$ and $P[E|U]$
   - There is only one opportunity for exposure per individuals; individuals are either exposed or not
-- Exposed individuals are infected ($I$) with probability $\lambda_V$ or $\lambda_U$
-- Infected individuals seek and receive a test with probability $\mu_{VI}$ or $\mu_{UI}$
-  - Note that this probability represents a combination of developing symptoms, seeking healthcare, and receiving a test given that healthcare was sought
-- Uninfected individuals ($X$) also seek and receive tests with unconditional probability $\mu_{VX}$ or $\mu_{UX}$
+- Exposed individuals are infected ($I$) with probability $P[I|E,V]$ or $P[I|E,U]$
+- Infected individuals seek and receive a test ($S$) with probability $P[S|I,V]$ or $P[S|I,U]$
+  - Note that this probability represents a combination of developing symptoms, seeking healthcare, and actually receiving a test
+- Uninfected individuals ($X$) also seek and receive tests, with unconditional probability $P[S|X,V]$ or $P[S|X,U]$
 - People who receive tests are either positive ($P$) or negative ($N$)
-- The test has imperfect sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$
+- The test has sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$
+  - E.g., $P[P|S,V] = p_\mathrm{sens}$
 
-#### Quantities of interest
+#### Quantity of interest
 
-We are interested in VE against infection conditioned on exposure:
+We are interested in protection against symptomatic disease, conditioned on exposure:
 
-$$
-1 - \frac{\lambda_V}{\lambda_U}
-$$
+```math
+\mathrm{VE}_{SP} = 1 - \frac{P[S | V, E]}{P[S | U, E]}
+```
+
+#### Measured quantities
 
 The expected values of the numbers of infected and uninfected, stratified by vaccination status, are:
 
@@ -98,50 +83,25 @@ The actual values from the TND trial are affected by test performance:
 An estimator of the desired quantity is:
 
 ```math
-\hat{\mathrm{VE}}_\mathrm{OR} = 1 - \frac{C_{PV} C_{NU}}{C_{PU} C_{NV}}
+\hat{\mathrm{VE}}_\mathrm{OR} = 1 - \frac{C_{VP} C_{UN}}{C_{UP} C_{VN}}
 ```
 
-The expected value of this estimator is:
+When there is perfect test performance, the TND counts reduce to the actual disease status counts, e.g., $C_{VP} = C_{VI}$. In this case, the expected value of the estimator is:
 
 ```math
-\begin{align*}
+\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 - \frac{P[E|V] \times P[I|E,V] \times P[S|I,V] \times P[S|X,U]}{P[E|U] \times P[I|E,U] \times P[S|I,U] \times P[S|X,V]}
+```
+
+If we further assume that:
+
+1. the probability of exposure is identical among the vaccinated and unvaccinated, i.e., $P[E|V] = P[E|U]$, and
+2. vaccination does not affect progression to testing among the uninfected, i.e., $P[S|X,U]=P[S|X,V]$
+
+then:
+
+```math
 \mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right]
-  &= 1 -
-    \frac{n v \left[\varepsilon_V \lambda_V \mu_{VI} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{VX} (1 - p_\mathrm{spec}) \right]}{n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{UX} (1 - p_\mathrm{spec}) \right]}
-    \times \frac{n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{UX} p_\mathrm{spec} \right]}{n v \left[\varepsilon_V \lambda_V \mu_{VI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{VX} p_\mathrm{spec} \right]} \\
-  &= 1 -
-    \frac{
-      \left[\varepsilon_V \lambda_V \mu_{VI} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{VX} (1 - p_\mathrm{spec}) \right] \times
-      \left[\varepsilon_U \lambda_U \mu_{UI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{UX} p_\mathrm{spec} \right]
-      }{
-        \left[\varepsilon_U \lambda_U \mu_{UI} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{UX} (1 - p_\mathrm{spec}) \right] \times
-        \left[\varepsilon_V \lambda_V \mu_{VI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{VX} p_\mathrm{spec} \right]
-      }
-\end{align*}
+  = 1 - \frac{P[S|E,V]}{P[S|E,U]}
 ```
 
-Assuming perfect test sensitivity and specificity:
-
-```math
-\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 -
-  \frac{
-    \varepsilon_V \lambda_V (1 - \varepsilon_U \lambda_U) \mu_{VI} \mu_{UX}
-    }{
-      \varepsilon_U \lambda_U (1 - \varepsilon_V \lambda_V) \mu_{VX} \mu_{UI}
-    }
-```
-
-Furthermore assume equivalent post-infection behavior among the vaccinated and unvaccinated. Specificially, the infected are equally likely to progress to symptoms and seek care, regardless of vaccination status, such that $\mu_{VI} = \mu_{UI}$, and similarly for the uninfected, such that $\mu_{VX} = \mu_{UX}$. Then:
-
-```math
-\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 -
-  \frac{\varepsilon_V \lambda_V (1 - \varepsilon_U \lambda_U)}{\varepsilon_U \lambda_U (1 - \varepsilon_V \lambda_V)}
-```
-
-If everyone is exposed $\varepsilon_V = \varepsilon_U = 1$, then:
-
-$$
-\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 - \frac{\lambda_V (1 - \lambda_U)}{\lambda_U (1 - \lambda_V)}
-$$
-
-which is an unbiased estimate of the odds ratio of protection.
+which is an unbiased estimator of $\mathrm{VE}_{SP}$.

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -1,0 +1,146 @@
+# Test-negative design: short primer
+
+## Draft outline
+
+- What is VE
+  - Known biases with any VE estimator
+- What is a TND study
+- There are 8 kinds of people:
+  - Vaccinated vs. not
+  - Infected with the focal pathogen vs. not
+  - Seek a test vs. not
+  - Test positive vs. not
+- TND has access only to people who seek a test
+- "Actual" VE is: [insert risk ratio math]
+- TND estimator of VE is: [insert odds ratio math]
+- Note that TND estimator is unbiased only when: [assumptions]
+- Bias of TND estimator scales this way with underlying parameters: [discuss]
+
+"HLS" refers to Halloran, Longini, and Struchiner _Design and Analysis of Vaccine Studies_.
+
+## Vaccine efficacy
+
+VE is the fractional reduction in the probability of an adverse outcome due to vaccination. For purposes of a test-negative design (TND) study, we further define VE to be:
+
+- A direct effect, that is, the counterfactual reduction in risk that would occur if a single individual were vaccinated or not, and not the population-level effect of reducing transmission via a vaccination program
+- VE against infection, written $\mathrm{VE}_S$ in HLS
+- Binary: Individuals are considered vaccinated or not (e.g., people who were vaccinated shortly before the outcome of interest may be classified as "unvaccinated" in the study, because they are presumed to have not yet been protected)
+- Conditioned on some probability or amount of exposure to disease
+
+Thus:
+
+$$
+\mathrm{VE} = 1 - \frac{P[\text{infected} | \text{vaccinated}]}{P[\text{infected} | \text{unvaccinated}]}
+$$
+
+## Test-negative design
+
+A test-negative design (TND) is a study design that can be used to estimate VE. In a TND:
+
+- The population of interest are those individuals who received a diagnostic test
+- The main covariate of interest is vaccination status
+- The outcome of interest is the test result (positive or negative)
+
+The data available in a TND ultimately reduces to a 2x2 table of counts:
+
+|               | Vaccinated | Unvaccinated |
+| ------------- | ---------- | ------------ |
+| Test positive | $C_{PV}$   | $C_{PU}$     |
+| Test negative | $C_{NV}$   | $C_{NU}$     |
+
+## Mathematical model
+
+### Single-exposure model
+
+- There is only one opportunity for exposure per individuals; individuals are either exposed or not
+- Individuals are vaccinated with probability $v$
+- Individuals are exposed with probability $\varepsilon_V$ or $\varepsilon_U$
+- Exposed individuals are infected ($I$) with probability $\lambda_V$ or $\lambda_U$
+- Infected individuals seek and receive a test with probability $\mu_{V|I}$ or $\mu_{U|I}$
+  - Note that this probability represents a combination of developing symptoms, seeking healthcare, and receiving a test given that healthcare was sought
+  - $1-\mu_V/\mu_U$ is an example of VE against progression conditional on an earlier outcome, written $\mathrm{VE}_P$ in HLS
+- Uninfected individuals ($X$) also seek and receive tests with probability $\mu_{V|X}$ or $\mu_{U|X}$
+- People who receive tests are either positive ($P$) or negative ($N$)
+- The test has imperfect sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$
+
+#### Quantities of interest
+
+We are interested in VE against infection conditioned on exposure:
+
+$$
+1 - \frac{\lambda_V}{\lambda_U}
+$$
+
+In a population of size $n$, the TND supplies counts whose expected values are:
+
+$$
+\begin{align*}
+\mathbb{E}[C_{PV}] &= n v \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right] \\
+\mathbb{E}[C_{NV}] &= n v \left[\varepsilon_V \lambda_V \mu_{V|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{V|X} p_\mathrm{spec} \right] \\
+\mathbb{E}[C_{PU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right] \\
+\mathbb{E}[C_{NU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{U|X} p_\mathrm{spec} \right] \\
+\end{align*}
+$$
+
+#### Risk ratio estimator
+
+One estimator is:
+
+$$
+\hat{\mathrm{VE}}_\mathrm{RR} \equiv 1 - \frac{C_{PV} / (C_{PV} + C_{NV})}{C_{PU} / (C_{PU} + C_{NU})}
+$$
+
+The expected value of this estimator is:
+
+$$
+\begin{align*}
+\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{RR}\right] &= 1 - \frac{nv \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]} \frac{n(1-v)}{nv} \\
+&= 1 - \frac{\left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{\left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]}
+\end{align*}
+$$
+
+This estimator is unbiased if:
+
+- Exposure probabilities are identical (e.g., vaccination status is uncorrelated with contact networks): $\varepsilon_V = \varepsilon_U$
+- Probability of receiving a test given infection is identical (i.e., vaccination does not protect against progression to symptomatic disease _and_ vaccination status is uncorrelated with healthcare seeking or probability of receiving a test given healthcare seeking)
+- The test has perfect sensitivity and specificity
+
+#### Odds ratio estimator
+
+Another estimator is:
+
+$$
+\hat{\mathrm{VE}}_\mathrm{OR} = 1 - \frac{C_{PV} C_{NU}}{C_{PU} C_{NV}}
+$$
+
+The expected value of this estimator is:
+
+$$
+\begin{align*}
+\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right]
+  &= 1 -
+    \frac{n v \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]}
+    \times \frac{n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{U|X} p_\mathrm{spec} \right]}{n v \left[\varepsilon_V \lambda_V \mu_{V|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{V|X} p_\mathrm{spec} \right]} \\
+  &= 1 -
+    \frac{
+      \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right] \times
+      \left[\varepsilon_U \lambda_U \mu_{U|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{U|X} p_\mathrm{spec} \right]
+      }{
+        \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right] \times
+        \left[\varepsilon_V \lambda_V \mu_{V|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{V|X} p_\mathrm{spec} \right]
+      }
+\end{align*}
+$$
+
+If we assume:
+
+- Equal exposure probabilities: $\varepsilon_V = \varepsilon_U$
+- Perfect sensitivity and specificity
+
+Then this reduces to:
+
+$$
+1 - \frac{\lambda_V (1 - \lambda_U)}{\lambda_U (1 - \lambda_V)}
+$$
+
+In other words, at the cost of estimating VE in terms of an odds ratio rather than a risk ratio, we remove the need to make assumptions about probabilities $\mu$. This removes assumptions about (1) the vaccine preventing progression from infection to symptoms that would drive healthcare seeking and (2) healthcare seeking given the development of symptoms.

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -34,9 +34,9 @@ The data available in a TND ultimately reduces to a 2x2 table of counts:
 
 ### Single-exposure model
 
-- Individuals are vaccinated $V$ with probability $v$, or unvaccinated $U$
+- Individuals are vaccinated ($V$) with probability $v$, or unvaccinated $U$
   - Here we assume perfect reporting about vaccine status; i.e., there is no one who is actually vaccinated who appears in the "not vaccinated" arm, nor vice versa
-- Individuals are exposed with probability $P[E|V]$ and $P[E|U]$
+- Individuals are exposed ($E$) with probability $P[E|V]$ or $P[E|U]$
   - There is only one opportunity for exposure per individuals; individuals are either exposed or not
 - Exposed individuals are infected ($I$) with probability $P[I|E,V]$ or $P[I|E,U]$
 - Infected individuals seek and receive a test ($S$) with probability $P[S|I,V]$ or $P[S|I,U]$

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -52,15 +52,14 @@ The data available in a TND ultimately reduces to a 2x2 table of counts:
 
 ### Single-exposure model
 
-- There is only one opportunity for exposure per individuals; individuals are either exposed or not
 - Individuals are vaccinated with probability $v$
   - Here we assume perfect reporting about vaccine status; i.e., there is no one who is actually vaccinated who appears in the "not vaccinated" arm, nor vice versa
 - Individuals are exposed with probability $\varepsilon_V$ or $\varepsilon_U$
+  - There is only one opportunity for exposure per individuals; individuals are either exposed or not
 - Exposed individuals are infected ($I$) with probability $\lambda_V$ or $\lambda_U$
 - Infected individuals seek and receive a test with probability $\mu_{VI}$ or $\mu_{UI}$
   - Note that this probability represents a combination of developing symptoms, seeking healthcare, and receiving a test given that healthcare was sought
-  - $1-\mu_V/\mu_U$ is an example of VE against progression conditional on an earlier outcome, written $\mathrm{VE}_P$ in HLS
-- Uninfected individuals ($X$) also seek and receive tests with probability $\mu_{VX}$ or $\mu_{UX}$
+- Uninfected individuals ($X$) also seek and receive tests with unconditional probability $\mu_{VX}$ or $\mu_{UX}$
 - People who receive tests are either positive ($P$) or negative ($N$)
 - The test has imperfect sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$
 
@@ -72,16 +71,27 @@ $$
 1 - \frac{\lambda_V}{\lambda_U}
 $$
 
-In a population of size $n$, the TND supplies counts whose expected values are:
+The expected values of the numbers of infected and uninfected, stratified by vaccination status, are:
 
-$$
+```math
 \begin{align*}
-\mathbb{E}[C_{PV}] &= n v \left[\varepsilon_V \lambda_V \mu_{VI} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{VX} (1 - p_\mathrm{spec}) \right] \\
-\mathbb{E}[C_{NV}] &= n v \left[\varepsilon_V \lambda_V \mu_{VI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{VX} p_\mathrm{spec} \right] \\
-\mathbb{E}[C_{PU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{UX} (1 - p_\mathrm{spec}) \right] \\
-\mathbb{E}[C_{NU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{UX} p_\mathrm{spec} \right] \\
+\mathbb{E}[C_{VI}] &= n v \times P[E|V] \times P[I|E,V] \times P[S|I,V] \\
+\mathbb{E}[C_{VX}] &= n v \times P[S|X,V] \\
+\mathbb{E}[C_{UI}] &= n (1-v) \times P[E|U] \times P[I|E,U] \times P[S|I,U] \\
+\mathbb{E}[C_{UX}] &= n (1-v) \times P[S|X,U] \\
 \end{align*}
-$$
+```
+
+The actual values from the TND trial are affected by test performance:
+
+```math
+\begin{align*}
+\mathbb{E}[C_{VP}] &= p_\mathrm{sens} \mathbb{E}[C_{VI}] + (1 - p_\mathrm{spec}) \mathbb{E}[C_{VX}] \\
+\mathbb{E}[C_{VN}] &= (1 - p_\mathrm{sens}) \mathbb{E}[C_{VI}] + p_\mathrm{spec} \mathbb{E}[C_{VX}] \\
+\mathbb{E}[C_{UP}] &= p_\mathrm{sens} \mathbb{E}[C_{UI}] + (1 - p_\mathrm{spec}) \mathbb{E}[C_{UX}] \\
+\mathbb{E}[C_{UN}] &= (1 - p_\mathrm{sens}) \mathbb{E}[C_{UI}] + p_\mathrm{spec} \mathbb{E}[C_{UX}] \\
+\end{align*}
+```
 
 #### Odds ratio estimator
 

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -86,18 +86,18 @@ $$
 
 One estimator is:
 
-$$
+```math
 \hat{\mathrm{VE}}_\mathrm{RR} \equiv 1 - \frac{C_{PV} / (C_{PV} + C_{NV})}{C_{PU} / (C_{PU} + C_{NU})}
-$$
+```
 
 The expected value of this estimator is:
 
-$$
+```math
 \begin{align*}
 \mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{RR}\right] &= 1 - \frac{nv \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]} \frac{n(1-v)}{nv} \\
 &= 1 - \frac{\left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{\left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]}
 \end{align*}
-$$
+```
 
 This estimator is unbiased if:
 
@@ -109,13 +109,13 @@ This estimator is unbiased if:
 
 Another estimator is:
 
-$$
+```math
 \hat{\mathrm{VE}}_\mathrm{OR} = 1 - \frac{C_{PV} C_{NU}}{C_{PU} C_{NV}}
-$$
+```
 
 The expected value of this estimator is:
 
-$$
+```math
 \begin{align*}
 \mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right]
   &= 1 -
@@ -130,7 +130,7 @@ $$
         \left[\varepsilon_V \lambda_V \mu_{V|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{V|X} p_\mathrm{spec} \right]
       }
 \end{align*}
-$$
+```
 
 If we assume:
 

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -36,15 +36,14 @@ The data available in a TND ultimately reduces to a 2x2 table of counts:
 
 - Individuals are vaccinated ($V$) with probability $v$, or unvaccinated $U$
   - Here we assume perfect reporting about vaccine status; i.e., there is no one who is actually vaccinated who appears in the "not vaccinated" arm, nor vice versa
-- Individuals are exposed ($E$) with probability $P[E|V]$ or $P[E|U]$
-  - There is only one opportunity for exposure per individuals; individuals are either exposed or not
-- Exposed individuals are infected ($I$) with probability $P[I|E,V]$ or $P[I|E,U]$
-- Infected individuals seek and receive a test ($S$) with probability $P[S|I,V]$ or $P[S|I,U]$
-  - Note that this probability represents a combination of developing symptoms, seeking healthcare, and actually receiving a test
-- Uninfected individuals ($X$) also seek and receive tests, with unconditional probability $P[S|X,V]$ or $P[S|X,U]$
+- Each individual has the possibility of becoming exposed $E$, infected $I$, and then seek and receive a test $S$, with conditional probabilities depending on vaccination status:
+  - E.g., the probability that a vaccinated person will receive a test is $P[E|V] \times P[I|E,V] \times P[S|I,V]$
+  - There is only one opportunity for exposure per individual
+  - Note that the $I \to S$ transition represents a combination of developing symptoms, seeking healthcare, and actually receiving a test
+- Every individual also has the opportunity to seek and receive a test for reasons unrelated to infection, while in uninfected status $X$
+  - E.g., the probability that a vaccinated person will seek a test like this is $P[S|X,V]$
 - People who receive tests are either positive ($P$) or negative ($N$)
-- The test has sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$
-  - E.g., $P[P|S,V] = p_\mathrm{sens}$
+  - The test has sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$, such that, e.g., $P[P|S,V] = p_\mathrm{sens}$
 
 #### Quantity of interest
 
@@ -83,13 +82,13 @@ The actual values from the TND trial are affected by test performance:
 An estimator of the desired quantity is:
 
 ```math
-\hat{\mathrm{VE}}_\mathrm{OR} = 1 - \frac{C_{VP} C_{UN}}{C_{UP} C_{VN}}
+\hat{\mathrm{VE}} = 1 - \frac{C_{VP} C_{UN}}{C_{UP} C_{VN}}
 ```
 
 When there is perfect test performance, the TND counts reduce to the actual disease status counts, e.g., $C_{VP} = C_{VI}$. In this case, the expected value of the estimator is:
 
 ```math
-\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 - \frac{P[E|V] \times P[I|E,V] \times P[S|I,V] \times P[S|X,U]}{P[E|U] \times P[I|E,U] \times P[S|I,U] \times P[S|X,V]}
+\mathbb{E}\left[\hat{\mathrm{VE}}\right] = 1 - \frac{P[E|V] \times P[I|E,V] \times P[S|I,V] \times P[S|X,U]}{P[E|U] \times P[I|E,U] \times P[S|I,U] \times P[S|X,V]}
 ```
 
 If we further assume that:
@@ -100,7 +99,7 @@ If we further assume that:
 then:
 
 ```math
-\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right]
+\mathbb{E}\left[\hat{\mathrm{VE}}\right]
   = 1 - \frac{P[S|E,V]}{P[S|E,U]}
 ```
 

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -5,9 +5,9 @@
 - What is VE
   - Known biases with any VE estimator
 - What is a TND study
-- There are 8 kinds of people:
+- There are 16 kinds of people:
   - Vaccinated vs. not
-  - Infected with the focal pathogen vs. not
+  - Infected with the pathogen of interest vs. not
   - Seek a test vs. not
   - Test positive vs. not
 - TND has access only to people who seek a test
@@ -54,12 +54,13 @@ The data available in a TND ultimately reduces to a 2x2 table of counts:
 
 - There is only one opportunity for exposure per individuals; individuals are either exposed or not
 - Individuals are vaccinated with probability $v$
+  - Here we assume perfect reporting about vaccine status; i.e., there is no one who is actually vaccinated who appears in the "not vaccinated" arm, nor vice versa
 - Individuals are exposed with probability $\varepsilon_V$ or $\varepsilon_U$
 - Exposed individuals are infected ($I$) with probability $\lambda_V$ or $\lambda_U$
-- Infected individuals seek and receive a test with probability $\mu_{V|I}$ or $\mu_{U|I}$
+- Infected individuals seek and receive a test with probability $\mu_{VI}$ or $\mu_{UI}$
   - Note that this probability represents a combination of developing symptoms, seeking healthcare, and receiving a test given that healthcare was sought
   - $1-\mu_V/\mu_U$ is an example of VE against progression conditional on an earlier outcome, written $\mathrm{VE}_P$ in HLS
-- Uninfected individuals ($X$) also seek and receive tests with probability $\mu_{V|X}$ or $\mu_{U|X}$
+- Uninfected individuals ($X$) also seek and receive tests with probability $\mu_{VX}$ or $\mu_{UX}$
 - People who receive tests are either positive ($P$) or negative ($N$)
 - The test has imperfect sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$
 
@@ -75,39 +76,16 @@ In a population of size $n$, the TND supplies counts whose expected values are:
 
 $$
 \begin{align*}
-\mathbb{E}[C_{PV}] &= n v \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right] \\
-\mathbb{E}[C_{NV}] &= n v \left[\varepsilon_V \lambda_V \mu_{V|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{V|X} p_\mathrm{spec} \right] \\
-\mathbb{E}[C_{PU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right] \\
-\mathbb{E}[C_{NU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{U|X} p_\mathrm{spec} \right] \\
+\mathbb{E}[C_{PV}] &= n v \left[\varepsilon_V \lambda_V \mu_{VI} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{VX} (1 - p_\mathrm{spec}) \right] \\
+\mathbb{E}[C_{NV}] &= n v \left[\varepsilon_V \lambda_V \mu_{VI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{VX} p_\mathrm{spec} \right] \\
+\mathbb{E}[C_{PU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{UX} (1 - p_\mathrm{spec}) \right] \\
+\mathbb{E}[C_{NU}] &= n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{UX} p_\mathrm{spec} \right] \\
 \end{align*}
 $$
 
-#### Risk ratio estimator
-
-One estimator is:
-
-```math
-\hat{\mathrm{VE}}_\mathrm{RR} \equiv 1 - \frac{C_{PV} / (C_{PV} + C_{NV})}{C_{PU} / (C_{PU} + C_{NU})}
-```
-
-The expected value of this estimator is:
-
-```math
-\begin{align*}
-\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{RR}\right] &= 1 - \frac{nv \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]} \frac{n(1-v)}{nv} \\
-&= 1 - \frac{\left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{\left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]}
-\end{align*}
-```
-
-This estimator is unbiased if:
-
-- Exposure probabilities are identical (e.g., vaccination status is uncorrelated with contact networks): $\varepsilon_V = \varepsilon_U$
-- Probability of receiving a test given infection is identical (i.e., vaccination does not protect against progression to symptomatic disease _and_ vaccination status is uncorrelated with healthcare seeking or probability of receiving a test given healthcare seeking)
-- The test has perfect sensitivity and specificity
-
 #### Odds ratio estimator
 
-Another estimator is:
+An estimator of the desired quantity is:
 
 ```math
 \hat{\mathrm{VE}}_\mathrm{OR} = 1 - \frac{C_{PV} C_{NU}}{C_{PU} C_{NV}}
@@ -119,15 +97,15 @@ The expected value of this estimator is:
 \begin{align*}
 \mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right]
   &= 1 -
-    \frac{n v \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right]}{n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right]}
-    \times \frac{n (1-v) \left[\varepsilon_U \lambda_U \mu_{U|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{U|X} p_\mathrm{spec} \right]}{n v \left[\varepsilon_V \lambda_V \mu_{V|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{V|X} p_\mathrm{spec} \right]} \\
+    \frac{n v \left[\varepsilon_V \lambda_V \mu_{VI} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{VX} (1 - p_\mathrm{spec}) \right]}{n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{UX} (1 - p_\mathrm{spec}) \right]}
+    \times \frac{n (1-v) \left[\varepsilon_U \lambda_U \mu_{UI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{UX} p_\mathrm{spec} \right]}{n v \left[\varepsilon_V \lambda_V \mu_{VI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{VX} p_\mathrm{spec} \right]} \\
   &= 1 -
     \frac{
-      \left[\varepsilon_V \lambda_V \mu_{V|I} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{V|X} (1 - p_\mathrm{spec}) \right] \times
-      \left[\varepsilon_U \lambda_U \mu_{U|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{U|X} p_\mathrm{spec} \right]
+      \left[\varepsilon_V \lambda_V \mu_{VI} p_\mathrm{sens} + (1 - \varepsilon_V \lambda_V) \mu_{VX} (1 - p_\mathrm{spec}) \right] \times
+      \left[\varepsilon_U \lambda_U \mu_{UI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_U \lambda_U) \mu_{UX} p_\mathrm{spec} \right]
       }{
-        \left[\varepsilon_U \lambda_U \mu_{U|I} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{U|X} (1 - p_\mathrm{spec}) \right] \times
-        \left[\varepsilon_V \lambda_V \mu_{V|I} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{V|X} p_\mathrm{spec} \right]
+        \left[\varepsilon_U \lambda_U \mu_{UI} p_\mathrm{sens} + (1 - \varepsilon_U \lambda_U) \mu_{UX} (1 - p_\mathrm{spec}) \right] \times
+        \left[\varepsilon_V \lambda_V \mu_{VI} (1 - p_\mathrm{sens}) + (1 - \varepsilon_V \lambda_V) \mu_{VX} p_\mathrm{spec} \right]
       }
 \end{align*}
 ```

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -5,15 +5,9 @@
 VE is the fractional reduction in the probability of an adverse outcome due to vaccination. For purposes of a test-negative design (TND) study, we further define VE to be:
 
 - A direct effect, that is, the counterfactual reduction in risk that would occur if a single individual were vaccinated or not, and not the population-level effect of reducing transmission via a vaccination program
-- VE against infection, written $\mathrm{VE}_S$ in HLS
-- Binary: Individuals are considered vaccinated or not (e.g., people who were vaccinated shortly before the outcome of interest may be classified as "unvaccinated" in the study, because they are presumed to have not yet been protected)
+- Protection against symptomatic disease that would lead to a diagnostic test, written $\mathrm{VE}_{SP}$ in Halloran, Longini, and Struchiner
 - Conditioned on some probability or amount of exposure to disease
-
-Thus:
-
-$$
-\mathrm{VE} = 1 - \frac{P[\text{infected} | \text{vaccinated}]}{P[\text{infected} | \text{unvaccinated}]}
-$$
+- Binary: Individuals are considered vaccinated or not (e.g., people who were vaccinated shortly before the outcome of interest may be classified as "unvaccinated" in the study, because they are presumed to have not yet been protected)
 
 ## Test-negative design
 
@@ -27,30 +21,30 @@ The data available in a TND ultimately reduces to a 2x2 table of counts:
 
 |               | Vaccinated | Unvaccinated |
 | ------------- | ---------- | ------------ |
-| Test positive | $C_{PV}$   | $C_{PU}$     |
-| Test negative | $C_{NV}$   | $C_{NU}$     |
+| Test positive | $C_{VP}$   | $C_{UP}$     |
+| Test negative | $C_{VN}$   | $C_{UN}$     |
 
 ## Mathematical model
 
 ### Single-exposure model
 
-- Individuals are vaccinated ($V$) with probability $v$, or unvaccinated $U$
+- Individuals are vaccinated ($V$) with probability $v$, or unvaccinated ($U$)
   - Here we assume perfect reporting about vaccine status; i.e., there is no one who is actually vaccinated who appears in the "not vaccinated" arm, nor vice versa
-- Each individual has the possibility of becoming exposed $E$, infected $I$, and then seek and receive a test $S$, with conditional probabilities depending on vaccination status:
-  - E.g., the probability that a vaccinated person will receive a test is $P[E|V] \times P[I|E,V] \times P[S|I,V]$
+- Each individual has the possibility of becoming exposed $E$, infected $I$, and then seek and receive a test $T$, with conditional probabilities depending on vaccination status:
+  - E.g., the probability that a vaccinated person will receive a test is $P[E|V] \times P[I|E,V] \times P[T|I,V]$
   - There is only one opportunity for exposure per individual
-  - Note that the $I \to S$ transition represents a combination of developing symptoms, seeking healthcare, and actually receiving a test
+  - Note that the $I \to T$ transition represents a combination of developing symptoms, seeking healthcare, and actually receiving a test
 - Every individual also has the opportunity to seek and receive a test for reasons unrelated to infection, while in uninfected status $X$
-  - E.g., the probability that a vaccinated person will seek a test like this is $P[S|X,V]$
+  - E.g., the probability that a vaccinated person will seek a test like this is $P[T|X,V]$
 - People who receive tests are either positive ($P$) or negative ($N$)
-  - The test has sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$, such that, e.g., $P[P|S,V] = p_\mathrm{sens}$
+  - The test has sensitivity $p_\mathrm{sens}$ and specificity $p_\mathrm{spec}$, such that, e.g., $P[P|T,V] = p_\mathrm{sens}$
 
 #### Quantity of interest
 
 We are interested in protection against symptomatic disease, conditioned on exposure:
 
 ```math
-\mathrm{VE}_{SP} = 1 - \frac{P[S | V, E]}{P[S | U, E]}
+\mathrm{VE}_{SP} = 1 - \frac{P[T | V, E]}{P[T | U, E]}
 ```
 
 #### Measured quantities
@@ -59,10 +53,10 @@ The expected values of the numbers of infected and uninfected, stratified by vac
 
 ```math
 \begin{align*}
-\mathbb{E}[C_{VI}] &= n v \times P[E|V] \times P[I|E,V] \times P[S|I,V] \\
-\mathbb{E}[C_{VX}] &= n v \times P[S|X,V] \\
-\mathbb{E}[C_{UI}] &= n (1-v) \times P[E|U] \times P[I|E,U] \times P[S|I,U] \\
-\mathbb{E}[C_{UX}] &= n (1-v) \times P[S|X,U] \\
+\mathbb{E}[C_{VI}] &= n v \times P[E|V] \times P[I|E,V] \times P[T|I,V] \\
+\mathbb{E}[C_{VX}] &= n v \times P[T|X,V] \\
+\mathbb{E}[C_{UI}] &= n (1-v) \times P[E|U] \times P[I|E,U] \times P[T|I,U] \\
+\mathbb{E}[C_{UX}] &= n (1-v) \times P[T|X,U] \\
 \end{align*}
 ```
 
@@ -88,19 +82,19 @@ An estimator of the desired quantity is:
 When there is perfect test performance, the TND counts reduce to the actual disease status counts, e.g., $C_{VP} = C_{VI}$. In this case, the expected value of the estimator is:
 
 ```math
-\mathbb{E}\left[\hat{\mathrm{VE}}\right] = 1 - \frac{P[E|V] \times P[I|E,V] \times P[S|I,V] \times P[S|X,U]}{P[E|U] \times P[I|E,U] \times P[S|I,U] \times P[S|X,V]}
+\mathbb{E}\left[\hat{\mathrm{VE}}\right] = 1 - \frac{P[E|V] \times P[I|E,V] \times P[T|I,V] \times P[T|X,U]}{P[E|U] \times P[I|E,U] \times P[T|I,U] \times P[T|X,V]}
 ```
 
 If we further assume that:
 
 1. the probability of exposure is identical among the vaccinated and unvaccinated, i.e., $P[E|V] = P[E|U]$, and
-2. vaccination does not affect progression to testing among the uninfected, i.e., $P[S|X,U]=P[S|X,V]$
+2. vaccination does not affect progression to testing among the uninfected, i.e., $P[T|X,U]=P[T|X,V]$
 
 then:
 
 ```math
 \mathbb{E}\left[\hat{\mathrm{VE}}\right]
-  = 1 - \frac{P[S|E,V]}{P[S|E,U]}
+  = 1 - \frac{P[T|E,V]}{P[T|E,U]}
 ```
 
 which is an unbiased estimator of $\mathrm{VE}_{SP}$.

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -4,10 +4,10 @@
 
 VE is the fractional reduction in the probability of an adverse outcome due to vaccination. For purposes of a test-negative design (TND) study, we further define VE to be:
 
-- A direct effect, that is, the counterfactual reduction in risk that would occur if a single individual were vaccinated or not, and not the population-level effect of reducing transmission via a vaccination program
-- Protection against symptomatic disease that would lead to a diagnostic test, written $\mathrm{VE}_{SP}$ in Halloran, Longini, and Struchiner
-- Conditioned on some probability or amount of exposure to disease
-- Binary: Individuals are considered vaccinated or not (e.g., people who were vaccinated shortly before the outcome of interest may be classified as "unvaccinated" in the study, because they are presumed to have not yet been protected)
+- a direct effect, that is, the counterfactual reduction in risk that would occur if a single individual were vaccinated or not, and not the population-level effect of reducing transmission via a vaccination program,
+- Protection against symptomatic disease that would lead to a diagnostic test, written $\mathrm{VE}_{SP}$ in [Halloran, Longini, and Struchiner](https://doi.org/10.1007/978-0-387-68636-3),
+- conditioned on some probability or amount of exposure to disease, and
+- binary, that is, individuals are considered vaccinated or not (e.g., people who were vaccinated shortly before the outcome of interest may be classified as "unvaccinated" in the study, because they are presumed to have not yet been protected).
 
 ## Test-negative design
 

--- a/docs/primer_short.md
+++ b/docs/primer_short.md
@@ -110,15 +110,28 @@ The expected value of this estimator is:
 \end{align*}
 ```
 
-If we assume:
+Assuming perfect test sensitivity and specificity:
 
-- Equal exposure probabilities: $\varepsilon_V = \varepsilon_U$
-- Perfect sensitivity and specificity
+```math
+\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 -
+  \frac{
+    \varepsilon_V \lambda_V (1 - \varepsilon_U \lambda_U) \mu_{VI} \mu_{UX}
+    }{
+      \varepsilon_U \lambda_U (1 - \varepsilon_V \lambda_V) \mu_{VX} \mu_{UI}
+    }
+```
 
-Then this reduces to:
+Furthermore assume equivalent post-infection behavior among the vaccinated and unvaccinated. Specificially, the infected are equally likely to progress to symptoms and seek care, regardless of vaccination status, such that $\mu_{VI} = \mu_{UI}$, and similarly for the uninfected, such that $\mu_{VX} = \mu_{UX}$. Then:
+
+```math
+\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 -
+  \frac{\varepsilon_V \lambda_V (1 - \varepsilon_U \lambda_U)}{\varepsilon_U \lambda_U (1 - \varepsilon_V \lambda_V)}
+```
+
+If everyone is exposed $\varepsilon_V = \varepsilon_U = 1$, then:
 
 $$
-1 - \frac{\lambda_V (1 - \lambda_U)}{\lambda_U (1 - \lambda_V)}
+\mathbb{E}\left[\hat{\mathrm{VE}}_\mathrm{OR}\right] = 1 - \frac{\lambda_V (1 - \lambda_U)}{\lambda_U (1 - \lambda_V)}
 $$
 
-In other words, at the cost of estimating VE in terms of an odds ratio rather than a risk ratio, we remove the need to make assumptions about probabilities $\mu$. This removes assumptions about (1) the vaccine preventing progression from infection to symptoms that would drive healthcare seeking and (2) healthcare seeking given the development of symptoms.
+which is an unbiased estimate of the odds ratio of protection.

--- a/tests/test_tnd.py
+++ b/tests/test_tnd.py
@@ -6,22 +6,27 @@ class TestEVRREstimator:
         """
         Assume:
           - perfect test performance
-          - same exposure probability
+          - exposure probability 1.0
           - same infection->test probability
         """
-        eps = 0.2
+        eps = 1.0
+        lam_v = 0.50
+        lam_u = 0.75
         mu_i = 0.4
-        current = tnd.ev_rr_estimator(
+        mu_x = 0.5
+        current = tnd.ev_estimator(
             eps_v=eps,
             eps_u=eps,
-            lam_v=0.8,
-            lam_u=1.0,
+            lam_v=lam_v,
+            lam_u=lam_u,
             mu_vi=mu_i,
             mu_ui=mu_i,
-            mu_vx=0.5,
-            mu_ux=0.5,
+            mu_vx=mu_x,
+            mu_ux=mu_x,
             sens=1.0,
             spec=1.0,
         )
 
-        assert current == 1.0 - 0.8 / 1.0
+        OR = lam_v / lam_u * (1 - lam_u) / (1 - lam_v)
+
+        assert current == 1.0 - OR

--- a/tnd/__init__.py
+++ b/tnd/__init__.py
@@ -1,18 +1,18 @@
 import numpy as np
 
 
-def ev_rr_estimator(
-    eps_v: np.ndarray,
-    eps_u: np.ndarray,
-    lam_v: np.ndarray,
-    lam_u: np.ndarray,
-    mu_vi: np.ndarray,
-    mu_ui: np.ndarray,
-    mu_vx: np.ndarray,
-    mu_ux: np.ndarray,
-    sens: np.ndarray,
-    spec: np.ndarray,
-) -> np.ndarray:
+def ev_estimator(
+    eps_v: float | np.ndarray,
+    eps_u: float | np.ndarray,
+    lam_v: float | np.ndarray,
+    lam_u: float | np.ndarray,
+    mu_vi: float | np.ndarray,
+    mu_ui: float | np.ndarray,
+    mu_vx: float | np.ndarray,
+    mu_ux: float | np.ndarray,
+    sens: float | np.ndarray,
+    spec: float | np.ndarray,
+) -> float | np.ndarray:
     """Expected value of risk ratio estimator
 
     Args:
@@ -30,6 +30,23 @@ def ev_rr_estimator(
     Returns:
         np.ndarray: expected value
     """
-    return 1.0 - (
-        eps_v * lam_v * mu_vi * sens + (1.0 - eps_v * lam_v) * mu_vx * (1.0 - spec)
-    ) / (eps_u * lam_u * mu_ui * sens + (1.0 - eps_u * lam_u) * mu_ux * (1.0 - spec))
+    # expected proportions of true infection status (i=infected or x=not)
+    # by vaccination status (v=vaccinated, u=not)
+    vi = eps_v * lam_v
+    vx = 1.0 - vi
+    ui = eps_u * lam_u
+    ux = 1.0 - ui
+
+    # proportions of those individuals who are tested (t)
+    tvi = vi * mu_vi
+    tvx = vx * mu_vx
+    tui = ui * mu_ui
+    tux = ux * mu_ux
+
+    # expected proportions of test outcomes (p=positive, n=negative)
+    pv = tvi * sens + tvx * (1.0 - spec)
+    nv = tvi * (1.0 - sens) + tvx * spec
+    pu = tui * sens + tux * (1.0 - spec)
+    nu = tui * (1.0 - sens) + tux * spec
+
+    return 1.0 - (pv * nu) / (pu * nv)


### PR DESCRIPTION
@eschrom This is the short derivation I was thinking of:

- Collapse a few of the probabilities
- Tweak the notation (to deal with the fact that "N" kind of sounds like population size, "not vaccination," "not infected," and "test negative")
- Include imperfect sensitivity and specificity
- Be a little more careful about the definition of VE and estimators